### PR TITLE
If the received log message is already in JSON don't create a new JSO…

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -49,6 +49,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 				Hostname: m.Container.Config.Hostname,
 			},
 		}
+
 		js, err := json.Marshal(msg)
 		if err != nil {
 			log.Println("logstash:", err)

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -1,0 +1,157 @@
+package logstash
+
+import (
+    "testing"
+    "github.com/stretchr/testify/assert"
+    "github.com/gliderlabs/logspout/router"
+    "net"
+    "github.com/fsouza/go-dockerclient"
+    "time"
+    "encoding/json"
+)
+
+var res string
+
+type MockConn struct {
+}
+
+func (m MockConn) Close() error {
+    return nil
+}
+
+func (m MockConn) Read(b []byte) (n int, err error) {
+    return 0, nil
+}
+
+func (m MockConn) Write(b []byte) (n int, err error) {
+    res = string(b)
+    return 0, nil
+}
+
+func (m MockConn) LocalAddr() net.Addr {
+    return nil
+}
+
+func (m MockConn) RemoteAddr() net.Addr {
+    return nil
+}
+
+func (m MockConn) SetDeadline(t time.Time) error {
+    return nil
+}
+
+func (m MockConn) SetReadDeadline(t time.Time) error {
+    return nil
+}
+
+func (m MockConn) SetWriteDeadline(t time.Time) error {
+    return nil
+}
+
+
+func TestStreamNotJson(t *testing.T) {
+    assert := assert.New(t)
+
+    conn := MockConn{}
+
+    adapter := LogstashAdapter{
+        route: new(router.Route),
+        conn:  conn,
+    }
+
+    assert.NotNil(adapter)
+
+    logstream := make(chan *router.Message)
+
+    containerConfig := docker.Config{}
+    containerConfig.Image = "image"
+    containerConfig.Hostname = "hostname"
+
+    container := docker.Container{}
+    container.Name = "name"
+    container.ID = "ID"
+    container.Config = &containerConfig
+
+    str := `foo bananas`
+
+    message := router.Message{
+        Container: &container,
+        Source: "FOOOOO",
+        Data: str,
+        Time: time.Now(),
+    }
+
+    go func() {
+        logstream <- &message
+        close(logstream)
+    }()
+
+    adapter.Stream(logstream)
+
+    var data map[string]interface{}
+    err := json.Unmarshal([]byte(res), &data)
+    assert.Nil(err)
+
+    assert.Equal("name", data["docker.name"])
+    assert.Equal("ID", data["docker.id"])
+    assert.Equal("image", data["docker.image"])
+    assert.Equal("hostname", data["docker.hostname"])
+    assert.Equal("foo bananas", data["message"])
+}
+
+func TestStreamJson(t *testing.T) {
+    assert := assert.New(t)
+
+    conn := MockConn{}
+
+    adapter := LogstashAdapter{
+        route: new(router.Route),
+        conn:  conn,
+    }
+
+    assert.NotNil(adapter)
+
+    logstream := make(chan *router.Message)
+
+    containerConfig := docker.Config{}
+    containerConfig.Image = "image"
+    containerConfig.Hostname = "hostname"
+
+    container := docker.Container{}
+    container.Name = "name"
+    container.ID = "ID"
+    container.Config = &containerConfig
+
+    str := `{ "remote_user": "-", "body_bytes_sent": "25", "request_time": "0.821", "status": "200", "request_method": "POST", "http_referrer": "-", "http_user_agent": "-" }`
+
+    message := router.Message{
+        Container: &container,
+        Source: "FOOOOO",
+        Data: str,
+        Time: time.Now(),
+    }
+
+    go func() {
+        logstream <- &message
+        close(logstream)
+    }()
+
+    adapter.Stream(logstream)
+
+    var data map[string]interface{}
+    err := json.Unmarshal([]byte(res), &data)
+    assert.Nil(err)
+
+    assert.Equal("name", data["docker.name"])
+    assert.Equal("ID", data["docker.id"])
+    assert.Equal("image", data["docker.image"])
+    assert.Equal("hostname", data["docker.hostname"])
+    assert.Equal("-", data["remote_user"])
+    assert.Equal("25", data["body_bytes_sent"])
+    assert.Equal("0.821", data["request_time"])
+    assert.Equal("200", data["status"])
+    assert.Equal("POST", data["request_method"])
+    assert.Equal("-", data["http_referrer"])
+    assert.Equal("-", data["http_user_agent"])
+}
+

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -1,13 +1,13 @@
 package logstash
 
 import (
-    "testing"
-    "github.com/stretchr/testify/assert"
-    "github.com/gliderlabs/logspout/router"
-    "net"
-    "github.com/fsouza/go-dockerclient"
-    "time"
-    "encoding/json"
+	"encoding/json"
+	"github.com/fsouza/go-dockerclient"
+	"github.com/gliderlabs/logspout/router"
+	"github.com/stretchr/testify/assert"
+	"net"
+	"testing"
+	"time"
 )
 
 var res string
@@ -16,142 +16,146 @@ type MockConn struct {
 }
 
 func (m MockConn) Close() error {
-    return nil
+	return nil
 }
 
 func (m MockConn) Read(b []byte) (n int, err error) {
-    return 0, nil
+	return 0, nil
 }
 
 func (m MockConn) Write(b []byte) (n int, err error) {
-    res = string(b)
-    return 0, nil
+	res = string(b)
+	return 0, nil
 }
 
 func (m MockConn) LocalAddr() net.Addr {
-    return nil
+	return nil
 }
 
 func (m MockConn) RemoteAddr() net.Addr {
-    return nil
+	return nil
 }
 
 func (m MockConn) SetDeadline(t time.Time) error {
-    return nil
+	return nil
 }
 
 func (m MockConn) SetReadDeadline(t time.Time) error {
-    return nil
+	return nil
 }
 
 func (m MockConn) SetWriteDeadline(t time.Time) error {
-    return nil
+	return nil
 }
 
-
 func TestStreamNotJson(t *testing.T) {
-    assert := assert.New(t)
+	assert := assert.New(t)
 
-    conn := MockConn{}
+	conn := MockConn{}
 
-    adapter := LogstashAdapter{
-        route: new(router.Route),
-        conn:  conn,
-    }
+	adapter := LogstashAdapter{
+		route: new(router.Route),
+		conn:  conn,
+	}
 
-    assert.NotNil(adapter)
+	assert.NotNil(adapter)
 
-    logstream := make(chan *router.Message)
+	logstream := make(chan *router.Message)
 
-    containerConfig := docker.Config{}
-    containerConfig.Image = "image"
-    containerConfig.Hostname = "hostname"
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
 
-    container := docker.Container{}
-    container.Name = "name"
-    container.ID = "ID"
-    container.Config = &containerConfig
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
 
-    str := `foo bananas`
+	str := `foo bananas`
 
-    message := router.Message{
-        Container: &container,
-        Source: "FOOOOO",
-        Data: str,
-        Time: time.Now(),
-    }
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
 
-    go func() {
-        logstream <- &message
-        close(logstream)
-    }()
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
 
-    adapter.Stream(logstream)
+	adapter.Stream(logstream)
 
-    var data map[string]interface{}
-    err := json.Unmarshal([]byte(res), &data)
-    assert.Nil(err)
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
 
-    assert.Equal("name", data["docker.name"])
-    assert.Equal("ID", data["docker.id"])
-    assert.Equal("image", data["docker.image"])
-    assert.Equal("hostname", data["docker.hostname"])
-    assert.Equal("foo bananas", data["message"])
+	assert.Equal("foo bananas", data["message"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
 }
 
 func TestStreamJson(t *testing.T) {
-    assert := assert.New(t)
+	assert := assert.New(t)
 
-    conn := MockConn{}
+	conn := MockConn{}
 
-    adapter := LogstashAdapter{
-        route: new(router.Route),
-        conn:  conn,
-    }
+	adapter := LogstashAdapter{
+		route: new(router.Route),
+		conn:  conn,
+	}
 
-    assert.NotNil(adapter)
+	assert.NotNil(adapter)
 
-    logstream := make(chan *router.Message)
+	logstream := make(chan *router.Message)
 
-    containerConfig := docker.Config{}
-    containerConfig.Image = "image"
-    containerConfig.Hostname = "hostname"
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
 
-    container := docker.Container{}
-    container.Name = "name"
-    container.ID = "ID"
-    container.Config = &containerConfig
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
 
-    str := `{ "remote_user": "-", "body_bytes_sent": "25", "request_time": "0.821", "status": "200", "request_method": "POST", "http_referrer": "-", "http_user_agent": "-" }`
+	str := `{ "remote_user": "-", "body_bytes_sent": "25", "request_time": "0.821", "status": "200", "request_method": "POST", "http_referrer": "-", "http_user_agent": "-" }`
 
-    message := router.Message{
-        Container: &container,
-        Source: "FOOOOO",
-        Data: str,
-        Time: time.Now(),
-    }
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
 
-    go func() {
-        logstream <- &message
-        close(logstream)
-    }()
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
 
-    adapter.Stream(logstream)
+	adapter.Stream(logstream)
 
-    var data map[string]interface{}
-    err := json.Unmarshal([]byte(res), &data)
-    assert.Nil(err)
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
 
-    assert.Equal("name", data["docker.name"])
-    assert.Equal("ID", data["docker.id"])
-    assert.Equal("image", data["docker.image"])
-    assert.Equal("hostname", data["docker.hostname"])
-    assert.Equal("-", data["remote_user"])
-    assert.Equal("25", data["body_bytes_sent"])
-    assert.Equal("0.821", data["request_time"])
-    assert.Equal("200", data["status"])
-    assert.Equal("POST", data["request_method"])
-    assert.Equal("-", data["http_referrer"])
-    assert.Equal("-", data["http_user_agent"])
+	assert.Equal("-", data["remote_user"])
+	assert.Equal("25", data["body_bytes_sent"])
+	assert.Equal("0.821", data["request_time"])
+	assert.Equal("200", data["status"])
+	assert.Equal("POST", data["request_method"])
+	assert.Equal("-", data["http_referrer"])
+	assert.Equal("-", data["http_user_agent"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
 }
-


### PR DESCRIPTION
…N structure with the message as escaped JSON. Instead reuse the already existing JSON object and just add the docker specific fields.

If the message is not in JSON do the same thing as before, i.e. create a new JSON structure with the message in the 'message' field.

This makes it possible to pass log output from e.g. nginx configured to log in JSON format unchanged (with just the docker fields added) to logstash, instead of ending up with the JSON from nginx as escaped JSON in the message field making it next to impossible to parse out with logstash.
