### PR TITLE
Added note for the udp adapter to be included

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # logspout-logstash
 A minimalistic adapter for github.com/gliderlabs/logspout to write to Logstash UDP
 
-Follow the instructions in https://github.com/gliderlabs/logspout/tree/master/custom on how to build your own Logspout container with custom modules. Basically just copy the contents of the custom folder and include github.com/looplab/logspout-logstash in modules.go.
+Follow the instructions in https://github.com/gliderlabs/logspout/tree/master/custom on how to build your own Logspout container with custom modules. Basically just copy the contents of the custom folder and include:
+
+```
+import (
+  _ "github.com/looplab/logspout-logstash"
+  _ "github.com/gliderlabs/logspout/transports/udp"
+)
+```
+
+in modules.go.
 
 Use by setting `ROUTE_URIS=logstash://host:port` to the Logstash host and port for UDP.
 


### PR DESCRIPTION
This plugin also requires the gliderlabs udp transport plugin and thus
should list that in its requirements. When I first tried to use this plugin i only had 

```
import (
  _ "github.com/looplab/logspout-logstash"
)
```

and got the error

```
unable to find adapter: logstash
```

which is generated by lines 24-26 in logstash.go.

Once i set my modules.go to have:

```
import (
  _ "github.com/looplab/logspout-logstash"
  _ "github.com/gliderlabs/logspout/transports/udp"
)
```

everything worked. This PR fixes the documentation, but somebody who is willing to do some testing should probably fix that error message as well.
