### PR TITLE
exit logspout on fatal error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ import (
 
 in modules.go.
 
-Use by setting `ROUTE_URIS=logstash://host:port` to the Logstash host and port for UDP.
+Use by setting `ROUTE_URIS=logstash://host:port` to the Logstash host and port for TCP.
 
 In your logstash config, set the input codec to `json` e.g:
 
 input {
-  udp {
+  tcp {
     port => 5000
     codec => json
   }

--- a/logstash.go
+++ b/logstash.go
@@ -54,10 +54,8 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			log.Println("logstash:", err)
 			continue
 		}
-		toWrite := ""
-		toWrite += js
-		toWrite += "\n"
-		_, err = a.conn.Write(toWrite)
+		js.WriteString("\n")
+		_, err = a.conn.Write(js)
 		if err != nil {
 			log.Println("fatal logstash:", err)
 			os.Exit(3)

--- a/logstash.go
+++ b/logstash.go
@@ -47,6 +47,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			ID:       m.Container.ID,
 			Image:    m.Container.Config.Image,
 			Hostname: m.Container.Config.Hostname,
+			Labels:   m.Container.Config.Labels
 		}
 		js, err := json.Marshal(msg)
 		if err != nil {
@@ -63,9 +64,10 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 
 // LogstashMessage is a simple JSON input to Logstash.
 type LogstashMessage struct {
-	Message  string `json:"message"`
-	Name     string `json:"docker.name"`
-	ID       string `json:"docker.id"`
-	Image    string `json:"docker.image"`
-	Hostname string `json:"docker.hostname"`
+	Message  string            `json:"message"`
+	Name     string            `json:"docker.name"`
+	ID       string            `json:"docker.id"`
+	Image    string            `json:"docker.image"`
+	Hostname string            `json:"docker.hostname"`
+	Labels   map[string]string `json:"docker.labels,omitempty"`
 }

--- a/logstash.go
+++ b/logstash.go
@@ -54,7 +54,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			log.Println("logstash:", err)
 			continue
 		}
-		_, err = a.conn.Write(js + "\n")
+		_, err = a.conn.Write(strings.join(js, "\n"))
 		if err != nil {
 			log.Println("fatal logstash:", err)
 			os.Exit(3)

--- a/logstash.go
+++ b/logstash.go
@@ -47,7 +47,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			ID:       m.Container.ID,
 			Image:    m.Container.Config.Image,
 			Hostname: m.Container.Config.Hostname,
-			Labels:   m.Container.Config.Labels
+			Labels:   m.Container.Config.Labels,
 		}
 		js, err := json.Marshal(msg)
 		if err != nil {

--- a/logstash.go
+++ b/logstash.go
@@ -14,7 +14,7 @@ func init() {
 	router.AdapterFactories.Register(NewLogstashAdapter, "logstash")
 }
 
-// LogstashAdapter is an adapter that streams UDP JSON to Logstash.
+// LogstashAdapter is an adapter that streams TCP JSON to Logstash.
 type LogstashAdapter struct {
 	conn  net.Conn
 	route *router.Route
@@ -22,7 +22,7 @@ type LogstashAdapter struct {
 
 // NewLogstashAdapter creates a LogstashAdapter with UDP as the default transport.
 func NewLogstashAdapter(route *router.Route) (router.LogAdapter, error) {
-	transport, found := router.AdapterTransports.Lookup(route.AdapterTransport("udp"))
+	transport, found := router.AdapterTransports.Lookup(route.AdapterTransport("tcp"))
 	if !found {
 		return nil, errors.New("unable to find adapter: " + route.Adapter)
 	}

--- a/logstash.go
+++ b/logstash.go
@@ -20,7 +20,7 @@ type LogstashAdapter struct {
 	route *router.Route
 }
 
-// NewLogstashAdapter creates a LogstashAdapter with UDP as the default transport.
+// NewLogstashAdapter creates a LogstashAdapter with TCP as the default transport.
 func NewLogstashAdapter(route *router.Route) (router.LogAdapter, error) {
 	transport, found := router.AdapterTransports.Lookup(route.AdapterTransport("tcp"))
 	if !found {
@@ -54,7 +54,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			log.Println("logstash:", err)
 			continue
 		}
-		_, err = a.conn.Write(js)
+		_, err = a.conn.Write(js + "\n")
 		if err != nil {
 			log.Println("fatal logstash:", err)
 			os.Exit(3)

--- a/logstash.go
+++ b/logstash.go
@@ -54,10 +54,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			log.Println("logstash:", err)
 			continue
 		}
-		toWrite := ""
-        toWrite = string(js) + "\n"
-
-		_, err = a.conn.Write([]byte(toWrite))
+		_, err = a.conn.Write([]byte(string(js) + "\n"))
 		if err != nil {
 			log.Println("fatal logstash:", err)
 			os.Exit(3)

--- a/logstash.go
+++ b/logstash.go
@@ -54,7 +54,10 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			log.Println("logstash:", err)
 			continue
 		}
-		_, err = a.conn.Write(strings.join(js, "\n"))
+		toWrite := ""
+		toWrite += js
+		toWrite += "\n"
+		_, err = a.conn.Write(toWrite)
 		if err != nil {
 			log.Println("fatal logstash:", err)
 			os.Exit(3)

--- a/logstash.go
+++ b/logstash.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net"
+	"os"
 
 	"github.com/gliderlabs/logspout/router"
 )
@@ -54,8 +55,8 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 		}
 		_, err = a.conn.Write(js)
 		if err != nil {
-			log.Println("logstash:", err)
-			continue
+			log.Println("fatal logstash:", err)
+			os.Exit(3)
 		}
 	}
 }

--- a/logstash.go
+++ b/logstash.go
@@ -54,7 +54,10 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			log.Println("logstash:", err)
 			continue
 		}
-		_, err = a.conn.Write(append(js, []byte("\n")))
+		toWrite := ""
+        toWrite = string(js) + "\n"
+
+		_, err = a.conn.Write([]byte(toWrite))
 		if err != nil {
 			log.Println("fatal logstash:", err)
 			os.Exit(3)

--- a/logstash.go
+++ b/logstash.go
@@ -54,8 +54,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			log.Println("logstash:", err)
 			continue
 		}
-		js.WriteString("\n")
-		_, err = a.conn.Write(js)
+		_, err = a.conn.Write(append(js, []byte("\n")))
 		if err != nil {
 			log.Println("fatal logstash:", err)
 			os.Exit(3)


### PR DESCRIPTION
rather than continuing on a connection error (which will never recover) exit the process so that the process manager can restart logspout

This should fix https://github.com/looplab/logspout-logstash/issues/7# and https://github.com/gliderlabs/logspout/issues/125
