### PR TITLE
#11: Uses underscores in place of dots in field names to support es 2.x

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -63,8 +63,8 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 // LogstashMessage is a simple JSON input to Logstash.
 type LogstashMessage struct {
 	Message  string `json:"message"`
-	Name     string `json:"docker.name"`
-	ID       string `json:"docker.id"`
-	Image    string `json:"docker.image"`
-	Hostname string `json:"docker.hostname"`
+	Name     string `json:"docker_name"`
+	ID       string `json:"docker_id"`
+	Image    string `json:"docker_image"`
+	Hostname string `json:"docker_hostname"`
 }


### PR DESCRIPTION
elastic/elasticsearch#14594 Field names cannot contain the . character in Elasticsearch 2.0
