### PR TITLE
Exit process on error

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net"
+	"os"
 
 	"github.com/gliderlabs/logspout/router"
 )
@@ -56,8 +57,8 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 		}
 		_, err = a.conn.Write(js)
 		if err != nil {
-			log.Println("logstash:", err)
-			continue
+			log.Println("fatal logstash:", err)
+			os.Exit(3)
 		}
 	}
 }


### PR DESCRIPTION
Rather than continuing on a connection error (which is never recovered anyway), exit so that process manager can restart logspout

The idea comes from https://github.com/mdx-dev/logspout-logstash/commit/f01110d01f9f18eb4ac3f6aba2294b5d634c6fbb

Replaces https://github.com/looplab/logspout-logstash/pull/8
