### PR TITLE
Introduce token for Logstash SaaS providers

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -104,5 +104,5 @@ type DockerInfo struct {
 type LogstashMessage struct {
 	Message string     `json:"message"`
 	Docker  DockerInfo `json:"docker"`
-	Token		string		 `json:"token"`
+	Token   string     `json:"token"`
 }

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -56,6 +56,7 @@ func TestStreamNotJson(t *testing.T) {
 	adapter := LogstashAdapter{
 		route: new(router.Route),
 		conn:  conn,
+		token: "test_token",
 	}
 
 	assert.NotNil(adapter)
@@ -92,6 +93,7 @@ func TestStreamNotJson(t *testing.T) {
 	assert.Nil(err)
 
 	assert.Equal("foo bananas", data["message"])
+	assert.Equal("test_token", data["token"])
 
 	var dockerInfo map[string]interface{}
 	dockerInfo = data["docker"].(map[string]interface{})
@@ -151,6 +153,7 @@ func TestStreamJson(t *testing.T) {
 	assert.Equal("POST", data["request_method"])
 	assert.Equal("-", data["http_referrer"])
 	assert.Equal("-", data["http_user_agent"])
+	assert.Nil(data["token"])
 
 	var dockerInfo map[string]interface{}
 	dockerInfo = data["docker"].(map[string]interface{})


### PR DESCRIPTION
Introduces an env-based token. When present, appended to logstash messages. Can be used to identify users in SaaS logstash environments such as logz.io.

Tests amended to validate token.
