### PR TITLE
A workaround on UDP connection refused issue when Logstash IP is changed

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -59,7 +59,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			}
 			js, err = json.Marshal(msg)
 			if err != nil {
-				log.Println("logstash-ye1:", err)
+				log.Println("logstash:", err)
 				continue
 			}
 		} else {
@@ -68,7 +68,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 
 			js, err = json.Marshal(jsonMsg)
 			if err != nil {
-				log.Println("logstash-ye2:", err)
+				log.Println("logstash:", err)
 				continue
 			}
 		}

--- a/logstash.go
+++ b/logstash.go
@@ -58,7 +58,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			}
 			js, err = json.Marshal(msg)
 			if err != nil {
-				log.Println("logstash:", err)
+				log.Println("logstash-ye1:", err)
 				continue
 			}
 		} else {
@@ -67,14 +67,14 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 
 			js, err = json.Marshal(jsonMsg)
 			if err != nil {
-				log.Println("logstash:", err)
+				log.Println("logstash-ye2:", err)
 				continue
 			}
 		}
 		_, err = a.conn.Write(js)
 		if err != nil {
-			log.Println("logstash:", err)
-			continue
+			log.Println("fatal logstash:", err)
+			os.Exit(3)
 		}
 	}
 }

--- a/logstash.go
+++ b/logstash.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net"
+	"os"
 
 	"github.com/gliderlabs/logspout/router"
 )


### PR DESCRIPTION
We deploy container services into Amazon ECS for both logspout and logstash; but if logstash service is restarted, the IP could be changed, but logspout-logstash module doesn't resolve the DNS after TTL, and it will bring a lot of "UDP connection refused" error and never come back to work.

I add few codes to make sure the logspout container will kill itself when UDP connection refused error happens, and Amazon ECS will automatically restart it, and then the correct IP will be resolved, and service can work again.

Of course, it's a workaround, and we are looking for the team can provide a better solution to resolve DNS after TTL.

Thanks
ye
