### PR TITLE
Adding TCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # logspout-logstash
-A minimalistic adapter for github.com/gliderlabs/logspout to write to Logstash UDP
+A minimalistic adapter for github.com/gliderlabs/logspout to write to Logstash
 
 Follow the instructions in https://github.com/gliderlabs/logspout/tree/master/custom on how to build your own Logspout container with custom modules. Basically just copy the contents of the custom folder and include:
 
-```
+```go
 import (
   _ "github.com/looplab/logspout-logstash"
   _ "github.com/gliderlabs/logspout/transports/udp"
@@ -12,14 +12,26 @@ import (
 
 in modules.go.
 
-Use by setting `ROUTE_URIS=logstash://host:port` to the Logstash host and port for UDP.
+Use by setting `ROUTE_URIS=logstash://host:port` to the Logstash host and port for UDP, or `ROUTE_URIS=logstash+tcp://host:port` for TCP.
 
 In your logstash config, set the input codec to `json` e.g:
 
+```
 input {
   udp {
     port => 5000
     codec => json
   }
 }
+```
 
+Or, to use TCP:
+
+```
+input {
+  tcp {
+    port => 5000
+    codec => json
+  }
+}
+```


### PR DESCRIPTION
Adds support for a second URL scheme `logstash+tcp` that will send logs over TCP connections instead of UDP connections. While UDP is generally higher-performance, TCP is more reliable, and there are certain Docker bugs that can cause real problems with UDP (such as docker/docker#8795).

Fixes #16 

Signed-off-by: Dave Henderson dhenderson@gmail.com
