### PR TITLE
Add ability for plugin to work with tls and tcp transports via json_lines codec

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -69,6 +69,9 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			}
 		}
 
+		// to work with tls and tcp transports via json_lines codec
+		js = append(js, byte('\n'))
+
 		if _, err := a.conn.Write(js); err != nil {
 			log.Fatal("logstash:", err)
 		}


### PR DESCRIPTION
Add ability for plugin to work with tls and tcp transports via json_lines logstash codec.

Logstash config:

```
tcp {
       port => 5045
       ssl_enable => true
       ssl_cert => "/path/to/my.crt"
       ssl_key => "/path/to/my.key"
       ssl_extra_chain_certs => [ "/path/to/my/ca.crt" ]
       codec => json_lines
       type => docker
}
```

or

```
tcp {
       port => 5045
       codec => json_lines
       type => docker
} 
```
