### PR TITLE
Fix LOGSTASH_TAGS functionality. Add test cases.

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -43,18 +43,19 @@ func NewLogstashAdapter(route *router.Route) (router.LogAdapter, error) {
 
 // Get container tags configured with the environment variable LOGSTASH_TAGS
 func GetContainerTags(c *docker.Container, a *LogstashAdapter) []string {
-	var tags []string
-	if val, ok := a.containerTags[c.ID]; ok {
-		tags = val
-	} else {
-		for _, e := range c.Config.Env {
-			if strings.HasPrefix(e, "LOGSTASH_TAGS=") {
-				tags = strings.Split(strings.TrimPrefix(e, "LOGSTASH_TAGS="), ",")
-				break
-			}
-		}
-		a.containerTags[c.ID] = tags
+	if tags, ok := a.containerTags[c.ID]; ok {
+		return tags
 	}
+
+	var tags = []string{}
+	for _, e := range c.Config.Env {
+		if strings.HasPrefix(e, "LOGSTASH_TAGS=") {
+			tags = strings.Split(strings.TrimPrefix(e, "LOGSTASH_TAGS="), ",")
+			break
+		}
+	}
+
+	a.containerTags[c.ID] = tags
 	return tags
 }
 

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -95,7 +95,7 @@ func TestStreamNotJsonWithoutLogstashTags(t *testing.T) {
 	assert.Nil(err)
 
 	assert.Equal("foo bananas", data["message"])
-	assert.Equal(nil, data["tags"])
+	assert.Equal([]interface{}{}, data["tags"])
 
 	var dockerInfo map[string]interface{}
 	dockerInfo = data["docker"].(map[string]interface{})
@@ -213,7 +213,7 @@ func TestStreamJsonWithoutLogstashTags(t *testing.T) {
 	assert.Equal("POST", data["request_method"])
 	assert.Equal("-", data["http_referrer"])
 	assert.Equal("-", data["http_user_agent"])
-	assert.Equal(nil, data["tags"])
+	assert.Equal([]interface{}{}, data["tags"])
 
 	var dockerInfo map[string]interface{}
 	dockerInfo = data["docker"].(map[string]interface{})

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -66,6 +66,7 @@ func TestStreamNotJson(t *testing.T) {
 	containerConfig := docker.Config{}
 	containerConfig.Image = "image"
 	containerConfig.Hostname = "hostname"
+	containerConfig.Env = []string{"LOGSTASH_TAGS=example,tags", "NON_LOGSTASH_TAGS=not,logstash"}
 
 	container := docker.Container{}
 	container.Name = "name"
@@ -93,6 +94,7 @@ func TestStreamNotJson(t *testing.T) {
 	assert.Nil(err)
 
 	assert.Equal("foo bananas", data["message"])
+	assert.Equal([]interface {}{"example", "tags"}, data["tags"])
 
 	var dockerInfo map[string]interface{}
 	dockerInfo = data["docker"].(map[string]interface{})
@@ -119,6 +121,7 @@ func TestStreamJson(t *testing.T) {
 	containerConfig := docker.Config{}
 	containerConfig.Image = "image"
 	containerConfig.Hostname = "hostname"
+	containerConfig.Env = []string{"LOGSTASH_TAGS=example,tags", "NON_LOGSTASH_TAGS=not,logstash"}
 
 	container := docker.Container{}
 	container.Name = "name"
@@ -152,6 +155,7 @@ func TestStreamJson(t *testing.T) {
 	assert.Equal("POST", data["request_method"])
 	assert.Equal("-", data["http_referrer"])
 	assert.Equal("-", data["http_user_agent"])
+	assert.Equal([]interface {}{"example", "tags"}, data["tags"])
 
 	var dockerInfo map[string]interface{}
 	dockerInfo = data["docker"].(map[string]interface{})


### PR DESCRIPTION
The LOGSTASH_TAGS functionality wasn't working because it was fetching the environment variable from OS instead of using Container.Config.Env

Fix this functionality and add test cases.

Note: This is the first time I've written anything in Go so if there's something that can be bettered I'll be glad to fix it
