### PR TITLE
Fields and defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.project

--- a/README.md
+++ b/README.md
@@ -59,9 +59,26 @@ The output into logstash should be like:
     ],
 ```
 
+You can also add arbitrary logstash fields to the event using the ```LOGSTASH_FIELDS``` container environment variable:
+
+```bash
+  # Add any number of arbitrary fields to your event
+  -e LOGSTASH_FIELDS="myfield=something,anotherfield=something_else"
+```
+
+The output into logstash should be like:
+
+```json
+    "myfield": "something",
+    "another_field": "something_else",
+```
+
+Both configuration options can be set for every individual container, or for the logspout-logstash
+container itself where they then become a default for all containers if not overridden there.
 
 This table shows all available configurations:
 
 | Environment Variable | Input Type | Default Value |
 |----------------------|------------|---------------|
 | LOGSTASH_TAGS        | array      | None          |
+| LOGSTAHS_FIELDS      | map        | None          |

--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ This table shows all available configurations:
 | Environment Variable | Input Type | Default Value |
 |----------------------|------------|---------------|
 | LOGSTASH_TAGS        | array      | None          |
-| LOGSTAHS_FIELDS      | map        | None          |
+| LOGSTASH_FIELDS      | map        | None          |

--- a/logstash.go
+++ b/logstash.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"strings"
+	"os"
 
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gliderlabs/logspout/router"
@@ -17,9 +18,10 @@ func init() {
 
 // LogstashAdapter is an adapter that streams UDP JSON to Logstash.
 type LogstashAdapter struct {
-	conn          net.Conn
-	route         *router.Route
-	containerTags map[string][]string
+	conn           net.Conn
+	route          *router.Route
+	containerTags  map[string][]string
+	logstashFields map[string]map[string]string
 }
 
 // NewLogstashAdapter creates a LogstashAdapter with UDP as the default transport.
@@ -35,9 +37,10 @@ func NewLogstashAdapter(route *router.Route) (router.LogAdapter, error) {
 	}
 
 	return &LogstashAdapter{
-		route:         route,
-		conn:          conn,
-		containerTags: make(map[string][]string),
+		route:          route,
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
 	}, nil
 }
 
@@ -47,17 +50,53 @@ func GetContainerTags(c *docker.Container, a *LogstashAdapter) []string {
 		return tags
 	}
 
-	var tags = []string{}
+	tags := []string {}
+	tags_str := os.Getenv("LOGSTASH_TAGS")
+
 	for _, e := range c.Config.Env {
 		if strings.HasPrefix(e, "LOGSTASH_TAGS=") {
-			tags = strings.Split(strings.TrimPrefix(e, "LOGSTASH_TAGS="), ",")
+			tags_str = strings.TrimPrefix(e, "LOGSTASH_TAGS=")
 			break
 		}
+	}
+
+	if len(tags_str) > 0 {
+		tags = strings.Split(tags_str, ",")
 	}
 
 	a.containerTags[c.ID] = tags
 	return tags
 }
+
+// Get logstash fields configured with the environment variable LOGSTASH_FIELDS
+func GetLogstashFields(c *docker.Container, a *LogstashAdapter) map[string]string {
+	if fields, ok := a.logstashFields[c.ID]; ok {
+		return fields
+	}
+
+	fields_str := os.Getenv("LOGSTASH_FIELDS")
+	fields := map[string]string {}
+
+	for _, e := range c.Config.Env {
+		if strings.HasPrefix(e, "LOGSTASH_FIELDS=") {
+			fields_str = strings.TrimPrefix(e, "LOGSTASH_FIELDS=")
+		}
+	}
+
+	if len(fields_str) > 0 {
+		for _, f := range strings.Split(fields_str, ",") {
+			sp := strings.Split(f, "=")
+			k, v := sp[0], sp[1]
+	    	fields[k] = v 
+		}
+	}
+
+	a.logstashFields[c.ID] = fields
+	
+	return fields
+}
+
+
 
 // Stream implements the router.LogAdapter interface.
 func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
@@ -72,20 +111,25 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 		}
 
 		tags := GetContainerTags(m.Container, a)
+		fields := GetLogstashFields(m.Container, a)
 
 		var js []byte
 		var data map[string]interface{}
 
 		// Parse JSON-encoded m.Data
 		if err := json.Unmarshal([]byte(m.Data), &data); err != nil {
-			// The message is not in JSON, make a new JSON message.
-			msg := LogstashMessage{
-				Message: m.Data,
-				Docker:  dockerInfo,
-				Stream:  m.Source,
-				Tags:    tags,
-			}
+			
+		    msg := make(map[string]interface{}) 
 
+			msg["message"] = m.Data
+			msg["docker"] = dockerInfo
+		    msg["stream"] = m.Source
+		    msg["tags"] = tags
+
+			for k, v := range fields { 
+			    msg[k] = v
+			}	
+		    
 			if js, err = json.Marshal(msg); err != nil {
 				// Log error message and continue parsing next line, if marshalling fails
 				log.Println("logstash: could not marshal JSON:", err)
@@ -96,6 +140,11 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			data["docker"] = dockerInfo
 			data["tags"] = tags
 			data["stream"] = m.Source
+
+			for k, v := range fields { 
+			    data[k] = v
+			}	
+		    
 			// Return the JSON encoding
 			if js, err = json.Marshal(data); err != nil {
 				// Log error message and continue parsing next line, if marshalling fails

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"testing"
 	"time"
+	"os"
 
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gliderlabs/logspout/router"
@@ -55,9 +56,10 @@ func TestStreamNotJsonWithoutLogstashTags(t *testing.T) {
 	conn := MockConn{}
 
 	adapter := LogstashAdapter{
-		route:         new(router.Route),
-		conn:          conn,
-		containerTags: make(map[string][]string),
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
 	}
 
 	assert.NotNil(adapter)
@@ -110,12 +112,13 @@ func TestStreamNotJsonWithLogstashTags(t *testing.T) {
 
 	conn := MockConn{}
 
-	adapter := LogstashAdapter{
-		route:         new(router.Route),
-		conn:          conn,
-		containerTags: make(map[string][]string),
+    adapter := LogstashAdapter{
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
 	}
-
+    
 	assert.NotNil(adapter)
 
 	logstream := make(chan *router.Message)
@@ -167,9 +170,10 @@ func TestStreamJsonWithoutLogstashTags(t *testing.T) {
 	conn := MockConn{}
 
 	adapter := LogstashAdapter{
-		route:         new(router.Route),
-		conn:          conn,
-		containerTags: make(map[string][]string),
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
 	}
 
 	assert.NotNil(adapter)
@@ -229,9 +233,10 @@ func TestStreamJsonWithLogstashTags(t *testing.T) {
 	conn := MockConn{}
 
 	adapter := LogstashAdapter{
-		route:         new(router.Route),
-		conn:          conn,
-		containerTags: make(map[string][]string),
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
 	}
 
 	assert.NotNil(adapter)
@@ -242,6 +247,382 @@ func TestStreamJsonWithLogstashTags(t *testing.T) {
 	containerConfig.Image = "image"
 	containerConfig.Hostname = "hostname"
 	containerConfig.Env = []string{"LOGSTASH_TAGS=example,tags", "NON_LOGSTASH_TAGS=not,logstash"}
+
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
+
+	str := `{ "remote_user": "-", "body_bytes_sent": "25", "request_time": "0.821", "status": "200", "request_method": "POST", "http_referrer": "-", "http_user_agent": "-" }`
+
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
+
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
+
+	adapter.Stream(logstream)
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
+
+	assert.Equal("-", data["remote_user"])
+	assert.Equal("25", data["body_bytes_sent"])
+	assert.Equal("0.821", data["request_time"])
+	assert.Equal("200", data["status"])
+	assert.Equal("POST", data["request_method"])
+	assert.Equal("-", data["http_referrer"])
+	assert.Equal("-", data["http_user_agent"])
+	assert.Equal([]interface{}{"example", "tags"}, data["tags"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
+}
+
+func TestStreamNotJsonWithLogstashFields(t *testing.T) {
+	assert := assert.New(t)
+
+	conn := MockConn{}
+
+    adapter := LogstashAdapter{
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
+	}
+    
+	assert.NotNil(adapter)
+
+	logstream := make(chan *router.Message)
+
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
+	containerConfig.Env = []string{"NON_LOGSTASH_TAGS=not,logstash", "LOGSTASH_FIELDS=myfield=something,anotherfield=something_else", "MORE_NON_LOGSTASH_TAGS=dont,include"}
+
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
+
+	str := `foo bananas`
+
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
+
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
+
+	adapter.Stream(logstream)
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
+
+	assert.Equal("foo bananas", data["message"])
+	assert.Equal([]interface{}{}, data["tags"])
+	assert.Equal("something", data["myfield"])
+	assert.Equal("something_else", data["anotherfield"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
+}
+
+func TestStreamJsonWithLogstashFields(t *testing.T) {
+	assert := assert.New(t)
+
+	conn := MockConn{}
+
+	adapter := LogstashAdapter{
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
+	}
+
+	assert.NotNil(adapter)
+
+	logstream := make(chan *router.Message)
+
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
+	containerConfig.Env = []string{"NON_LOGSTASH_TAGS=not,logstash", "LOGSTASH_FIELDS=myfield=something,anotherfield=something_else", "MORE_NON_LOGSTASH_TAGS=dont,include"}
+
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
+
+	str := `{ "remote_user": "-", "body_bytes_sent": "25", "request_time": "0.821", "status": "200", "request_method": "POST", "http_referrer": "-", "http_user_agent": "-" }`
+
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
+
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
+
+	adapter.Stream(logstream)
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
+
+	assert.Equal("-", data["remote_user"])
+	assert.Equal("25", data["body_bytes_sent"])
+	assert.Equal("0.821", data["request_time"])
+	assert.Equal("200", data["status"])
+	assert.Equal("POST", data["request_method"])
+	assert.Equal("-", data["http_referrer"])
+	assert.Equal("-", data["http_user_agent"])
+	assert.Equal([]interface{}{}, data["tags"])
+	assert.Equal("something", data["myfield"])
+	assert.Equal("something_else", data["anotherfield"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
+}
+
+func TestStreamNotJsonWithLogstashFieldsWithDefault(t *testing.T) {
+	assert := assert.New(t)
+
+	os.Setenv("LOGSTASH_FIELDS", "myfield=something,anotherfield=something_else")
+
+	conn := MockConn{}
+
+    adapter := LogstashAdapter{
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
+	}
+    
+	assert.NotNil(adapter)
+
+	logstream := make(chan *router.Message)
+
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
+	containerConfig.Env = []string{"NON_LOGSTASH_TAGS=not,logstash", "MORE_NON_LOGSTASH_TAGS=dont,include"}
+
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
+
+	str := `foo bananas`
+
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
+
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
+
+	adapter.Stream(logstream)
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
+
+	assert.Equal("foo bananas", data["message"])
+	assert.Equal([]interface{}{}, data["tags"])
+	assert.Equal("something", data["myfield"])
+	assert.Equal("something_else", data["anotherfield"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
+}
+
+func TestStreamJsonWithLogstashFieldsWithDefault(t *testing.T) {
+	assert := assert.New(t)
+
+	os.Setenv("LOGSTASH_FIELDS", "myfield=something,anotherfield=something_else")
+
+	conn := MockConn{}
+
+	adapter := LogstashAdapter{
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
+	}
+
+	assert.NotNil(adapter)
+
+	logstream := make(chan *router.Message)
+
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
+	containerConfig.Env = []string{"NON_LOGSTASH_TAGS=not,logstash", "MORE_NON_LOGSTASH_TAGS=dont,include"}
+
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
+
+	str := `{ "remote_user": "-", "body_bytes_sent": "25", "request_time": "0.821", "status": "200", "request_method": "POST", "http_referrer": "-", "http_user_agent": "-" }`
+
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
+
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
+
+	adapter.Stream(logstream)
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
+
+	assert.Equal("-", data["remote_user"])
+	assert.Equal("25", data["body_bytes_sent"])
+	assert.Equal("0.821", data["request_time"])
+	assert.Equal("200", data["status"])
+	assert.Equal("POST", data["request_method"])
+	assert.Equal("-", data["http_referrer"])
+	assert.Equal("-", data["http_user_agent"])
+	assert.Equal([]interface{}{}, data["tags"])
+	assert.Equal("something", data["myfield"])
+	assert.Equal("something_else", data["anotherfield"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
+}
+
+func TestStreamNotJsonWithLogstashTagsWithDefault(t *testing.T) {
+	assert := assert.New(t)
+
+	os.Setenv("LOGSTASH_TAGS", "example,tags")
+
+	conn := MockConn{}
+
+    adapter := LogstashAdapter{
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
+	}
+    
+	assert.NotNil(adapter)
+
+	logstream := make(chan *router.Message)
+
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
+	containerConfig.Env = []string{"NON_LOGSTASH_TAGS=not,logstash", "MORE_NON_LOGSTASH_TAGS=dont,include"}
+
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
+
+	str := `foo bananas`
+
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
+
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
+
+	adapter.Stream(logstream)
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
+
+	assert.Equal("foo bananas", data["message"])
+	assert.Equal([]interface{}{"example", "tags"}, data["tags"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
+}
+
+func TestStreamJsonWithLogstashTagsWithDefault(t *testing.T) {
+	assert := assert.New(t)
+
+	os.Setenv("LOGSTASH_TAGS", "example,tags")
+
+	conn := MockConn{}
+
+	adapter := LogstashAdapter{
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
+	}
+
+	assert.NotNil(adapter)
+
+	logstream := make(chan *router.Message)
+
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
+	containerConfig.Env = []string{"NON_LOGSTASH_TAGS=not,logstash"}
 
 	container := docker.Container{}
 	container.Name = "name"

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -3,9 +3,9 @@ package logstash
 import (
 	"encoding/json"
 	"net"
+	"os"
 	"testing"
 	"time"
-	"os"
 
 	"github.com/fsouza/go-dockerclient"
 	"github.com/gliderlabs/logspout/router"
@@ -112,13 +112,13 @@ func TestStreamNotJsonWithLogstashTags(t *testing.T) {
 
 	conn := MockConn{}
 
-    adapter := LogstashAdapter{
+	adapter := LogstashAdapter{
 		route:          new(router.Route),
 		conn:           conn,
 		containerTags:  make(map[string][]string),
 		logstashFields: make(map[string]map[string]string),
 	}
-    
+
 	assert.NotNil(adapter)
 
 	logstream := make(chan *router.Message)
@@ -295,13 +295,13 @@ func TestStreamNotJsonWithLogstashFields(t *testing.T) {
 
 	conn := MockConn{}
 
-    adapter := LogstashAdapter{
+	adapter := LogstashAdapter{
 		route:          new(router.Route),
 		conn:           conn,
 		containerTags:  make(map[string][]string),
 		logstashFields: make(map[string]map[string]string),
 	}
-    
+
 	assert.NotNil(adapter)
 
 	logstream := make(chan *router.Message)
@@ -421,13 +421,13 @@ func TestStreamNotJsonWithLogstashFieldsWithDefault(t *testing.T) {
 
 	conn := MockConn{}
 
-    adapter := LogstashAdapter{
+	adapter := LogstashAdapter{
 		route:          new(router.Route),
 		conn:           conn,
 		containerTags:  make(map[string][]string),
 		logstashFields: make(map[string]map[string]string),
 	}
-    
+
 	assert.NotNil(adapter)
 
 	logstream := make(chan *router.Message)
@@ -549,13 +549,13 @@ func TestStreamNotJsonWithLogstashTagsWithDefault(t *testing.T) {
 
 	conn := MockConn{}
 
-    adapter := LogstashAdapter{
+	adapter := LogstashAdapter{
 		route:          new(router.Route),
 		conn:           conn,
 		containerTags:  make(map[string][]string),
 		logstashFields: make(map[string]map[string]string),
 	}
-    
+
 	assert.NotNil(adapter)
 
 	logstream := make(chan *router.Message)
@@ -657,6 +657,139 @@ func TestStreamJsonWithLogstashTagsWithDefault(t *testing.T) {
 	assert.Equal("-", data["http_referrer"])
 	assert.Equal("-", data["http_user_agent"])
 	assert.Equal([]interface{}{"example", "tags"}, data["tags"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
+}
+
+func TestStreamJsonWithLogstashFieldsAndBlacklist(t *testing.T) {
+	assert := assert.New(t)
+
+	conn := MockConn{}
+
+	adapter := LogstashAdapter{
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
+	}
+
+	assert.NotNil(adapter)
+
+	logstream := make(chan *router.Message)
+
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
+	containerConfig.Env = []string{"LOGSTASH_FIELDS=myfield=something,anotherfield=something_else,tags=nastytag,docker=cheating", "LOGSTASH_TAGS=mytag,anothertag"}
+
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
+
+	str := `{ "remote_user": "-", "body_bytes_sent": "25", "request_time": "0.821", "status": "200", "request_method": "POST", "http_referrer": "-", "http_user_agent": "-" }`
+
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
+
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
+
+	adapter.Stream(logstream)
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
+
+	assert.Equal("-", data["remote_user"])
+	assert.Equal("25", data["body_bytes_sent"])
+	assert.Equal("0.821", data["request_time"])
+	assert.Equal("200", data["status"])
+	assert.Equal("POST", data["request_method"])
+	assert.Equal("-", data["http_referrer"])
+	assert.Equal("-", data["http_user_agent"])
+	assert.Equal([]interface{}{"mytag", "anothertag"}, data["tags"])
+	assert.Equal("something", data["myfield"])
+	assert.Equal("something_else", data["anotherfield"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
+}
+
+func TestStreamJsonWithLogstashFieldsWithDefaultAndBlacklist(t *testing.T) {
+	assert := assert.New(t)
+
+	os.Setenv("LOGSTASH_FIELDS", "myfield=something,anotherfield=something_else,tags=nastytag,docker=cheating")
+	os.Setenv("LOGSTASH_TAGS", "nicetag,righttag")
+
+	conn := MockConn{}
+
+	adapter := LogstashAdapter{
+		route:          new(router.Route),
+		conn:           conn,
+		containerTags:  make(map[string][]string),
+		logstashFields: make(map[string]map[string]string),
+	}
+
+	assert.NotNil(adapter)
+
+	logstream := make(chan *router.Message)
+
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
+	containerConfig.Env = []string{"NON_LOGSTASH_TAGS=not,logstash", "MORE_NON_LOGSTASH_TAGS=dont,include"}
+
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
+
+	str := `{ "remote_user": "-", "body_bytes_sent": "25", "request_time": "0.821", "status": "200", "request_method": "POST", "http_referrer": "-", "http_user_agent": "-" }`
+
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
+
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
+
+	adapter.Stream(logstream)
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
+
+	assert.Equal("-", data["remote_user"])
+	assert.Equal("25", data["body_bytes_sent"])
+	assert.Equal("0.821", data["request_time"])
+	assert.Equal("200", data["status"])
+	assert.Equal("POST", data["request_method"])
+	assert.Equal("-", data["http_referrer"])
+	assert.Equal("-", data["http_user_agent"])
+	assert.Equal([]interface{}{"nicetag", "righttag"}, data["tags"])
+	assert.Equal("something", data["myfield"])
+	assert.Equal("something_else", data["anotherfield"])
 
 	var dockerInfo map[string]interface{}
 	dockerInfo = data["docker"].(map[string]interface{})


### PR DESCRIPTION
This adds a new configuration option LOGSTASH_FIELDS for setting any logstash fields, and uses the values of LOGSTASH_FIELDS and LOGSTASH_TAGS for the logspout-logstash as a default for all containers if not set there (see #35).
