### PR TITLE
Allow logspout-side data config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ input {
 }
 ```
 
-## Available configuration options
+## Logged Container Options
+
+These options may be set on the container generating the log lines, not on the
+logstash-logspout container.
 
 For example, to get into the Logstash event's @tags field, use the ```LOGSTASH_TAGS``` container environment variable. Multiple tags can be passed by using comma-separated values
 
@@ -62,9 +65,19 @@ The output into logstash should be like:
     ],
 ```
 
-
 This table shows all available configurations:
 
 | Environment Variable | Input Type | Default Value |
 |----------------------|------------|---------------|
 | LOGSTASH_TAGS        | array      | None          |
+
+
+## Logstash-logspout Options
+
+These options may be set on the logstash-logspout container itself and impact
+all the log messages processed by the logstash-logspout instance.
+
+| Environment Variable   | Type  | Default | Description |
+|------------------------|-------|---------|-------------|
+| LOGSTASH_GLOBAL_TAGS   | array | None    | List of tags to apply to all messages |
+| LOGSTASH_INCLUDE_LABELS| array | None    | List of labels from remote container to include in log metadata |

--- a/logstash.go
+++ b/logstash.go
@@ -34,12 +34,17 @@ func filterTags(tags []string) []string {
 	return out
 }
 
+func multivalOpt(name string) []string {
+	return filterTags(strings.Split(getopt(name, ""), ","))
+}
+
 // LogstashAdapter is an adapter that streams UDP JSON to Logstash.
 type LogstashAdapter struct {
 	conn          net.Conn
 	route         *router.Route
 	containerTags map[string][]string
 	globalTags    []string
+	includeLabels []string
 }
 
 // NewLogstashAdapter creates a LogstashAdapter with UDP as the default transport.
@@ -58,7 +63,8 @@ func NewLogstashAdapter(route *router.Route) (router.LogAdapter, error) {
 		route:         route,
 		conn:          conn,
 		containerTags: make(map[string][]string),
-		globalTags:    filterTags(strings.Split(getopt("LOGSTASH_GLOBAL_TAGS", ""), ",")),
+		globalTags:    multivalOpt("LOGSTASH_GLOBAL_TAGS"),
+		includeLabels: multivalOpt("LOGSTASH_INCLUDE_LABELS"),
 	}, nil
 }
 
@@ -83,6 +89,21 @@ func GetContainerTags(c *docker.Container, a *LogstashAdapter) []string {
 	return tags
 }
 
+// Get container labels as configured with LOGSTASH_INCLUDE_LABELS
+func GetContainerLabels(c *docker.Container, a *LogstashAdapter) map[string]string {
+	var labels map[string]string
+	labels = make(map[string]string)
+
+	for _, label := range a.includeLabels {
+		_, exists := c.Config.Labels[label]
+		if exists {
+			labels[label] = c.Config.Labels[label]
+		}
+	}
+
+	return labels
+}
+
 // Stream implements the router.LogAdapter interface.
 func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 
@@ -93,6 +114,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 			ID:       m.Container.ID,
 			Image:    m.Container.Config.Image,
 			Hostname: m.Container.Config.Hostname,
+			Labels:   GetContainerLabels(m.Container, a),
 		}
 
 		tags := GetContainerTags(m.Container, a)
@@ -143,6 +165,7 @@ type DockerInfo struct {
 	ID       string `json:"id"`
 	Image    string `json:"image"`
 	Hostname string `json:"hostname"`
+	Labels   map[string]string `json:"labels"`
 }
 
 // LogstashMessage is a simple JSON input to Logstash.

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -58,6 +58,7 @@ func TestStreamNotJsonWithoutLogstashTags(t *testing.T) {
 		route:         new(router.Route),
 		conn:          conn,
 		containerTags: make(map[string][]string),
+		globalTags:    []string{},
 	}
 
 	assert.NotNil(adapter)
@@ -114,6 +115,7 @@ func TestStreamNotJsonWithLogstashTags(t *testing.T) {
 		route:         new(router.Route),
 		conn:          conn,
 		containerTags: make(map[string][]string),
+		globalTags:    []string{"global", "foo"},
 	}
 
 	assert.NotNil(adapter)
@@ -151,7 +153,7 @@ func TestStreamNotJsonWithLogstashTags(t *testing.T) {
 	assert.Nil(err)
 
 	assert.Equal("foo bananas", data["message"])
-	assert.Equal([]interface{}{"example", "tags"}, data["tags"])
+	assert.Equal([]interface{}{"example", "tags", "global", "foo"}, data["tags"])
 
 	var dockerInfo map[string]interface{}
 	dockerInfo = data["docker"].(map[string]interface{})
@@ -170,6 +172,7 @@ func TestStreamJsonWithoutLogstashTags(t *testing.T) {
 		route:         new(router.Route),
 		conn:          conn,
 		containerTags: make(map[string][]string),
+		globalTags:    []string{},
 	}
 
 	assert.NotNil(adapter)
@@ -232,6 +235,7 @@ func TestStreamJsonWithLogstashTags(t *testing.T) {
 		route:         new(router.Route),
 		conn:          conn,
 		containerTags: make(map[string][]string),
+		globalTags:    []string{"global", "foo"},
 	}
 
 	assert.NotNil(adapter)
@@ -275,7 +279,7 @@ func TestStreamJsonWithLogstashTags(t *testing.T) {
 	assert.Equal("POST", data["request_method"])
 	assert.Equal("-", data["http_referrer"])
 	assert.Equal("-", data["http_user_agent"])
-	assert.Equal([]interface{}{"example", "tags"}, data["tags"])
+	assert.Equal([]interface{}{"example", "tags", "global", "foo"}, data["tags"])
 
 	var dockerInfo map[string]interface{}
 	dockerInfo = data["docker"].(map[string]interface{})

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -288,3 +288,134 @@ func TestStreamJsonWithLogstashTags(t *testing.T) {
 	assert.Equal("image", dockerInfo["image"])
 	assert.Equal("hostname", dockerInfo["hostname"])
 }
+
+func TestStreamNotJsonWithoutLabels(t *testing.T) {
+	assert := assert.New(t)
+
+	conn := MockConn{}
+
+	adapter := LogstashAdapter{
+		route:         new(router.Route),
+		conn:          conn,
+		containerTags: make(map[string][]string),
+		globalTags:    []string{},
+		includeLabels: []string{},
+	}
+
+	assert.NotNil(adapter)
+
+	logstream := make(chan *router.Message)
+
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
+	containerConfig.Labels = map[string]string{
+		"label.test": "value",
+		"label.foo": "bar",
+		"label.other": "do not include",
+	}
+
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
+
+	str := `foo bananas`
+
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
+
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
+
+	adapter.Stream(logstream)
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
+
+	assert.Equal("foo bananas", data["message"])
+	assert.Equal([]interface{}{}, data["tags"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
+	assert.Len(dockerInfo["labels"], 0)
+}
+
+func TestStreamNotJsonWithLabels(t *testing.T) {
+	assert := assert.New(t)
+
+	conn := MockConn{}
+
+	adapter := LogstashAdapter{
+		route:         new(router.Route),
+		conn:          conn,
+		containerTags: make(map[string][]string),
+		globalTags:    []string{},
+		includeLabels: []string{"label.test", "label.foo"},
+	}
+
+	assert.NotNil(adapter)
+
+	logstream := make(chan *router.Message)
+
+	containerConfig := docker.Config{}
+	containerConfig.Image = "image"
+	containerConfig.Hostname = "hostname"
+	containerConfig.Labels = map[string]string{
+		"label.test": "value",
+		"label.foo": "bar",
+		"label.other": "do not include",
+	}
+
+	container := docker.Container{}
+	container.Name = "name"
+	container.ID = "ID"
+	container.Config = &containerConfig
+
+	str := `foo bananas`
+
+	message := router.Message{
+		Container: &container,
+		Source:    "FOOOOO",
+		Data:      str,
+		Time:      time.Now(),
+	}
+
+	go func() {
+		logstream <- &message
+		close(logstream)
+	}()
+
+	adapter.Stream(logstream)
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(res), &data)
+	assert.Nil(err)
+
+	assert.Equal("foo bananas", data["message"])
+	assert.Equal([]interface{}{}, data["tags"])
+
+	var dockerInfo map[string]interface{}
+	dockerInfo = data["docker"].(map[string]interface{})
+	assert.Equal("name", dockerInfo["name"])
+	assert.Equal("ID", dockerInfo["id"])
+	assert.Equal("image", dockerInfo["image"])
+	assert.Equal("hostname", dockerInfo["hostname"])
+
+	var labels map[string]interface{}
+	labels = dockerInfo["labels"].(map[string]interface{})
+	assert.Equal("value", labels["label.test"])
+	assert.Equal("bar", labels["label.foo"])
+	assert.Len(labels, 2)
+}


### PR DESCRIPTION
This PR includes two changes:

- Apply tags from LOGSTASH_GLOBAL_TAGS to all messages
- Send labels white-listed by LOGSTASH_INCLUDE_LABELS

These are two features that allow manipulation of the data that logspout-logstash will send by configuring the logspout instance rather than relying on configuration of each individual container to be logged.