### PR TITLE
Add timestamp field

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -129,6 +129,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 		data["docker"] = dockerInfo
 		data["stream"] = m.Source
 		data["tags"] = tags
+		data["timestamp"] = m.Time
 
 		// Return the JSON encoding
 		if js, err = json.Marshal(data); err != nil {


### PR DESCRIPTION
Added timestamp field provided by logspout to make it easier to index to ElasticSearch with correct time using:

```
date {
  match => [ "timestamp", "ISO8601" ]
}
```