### PR TITLE
Logging `null` bugfix

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -131,7 +131,7 @@ func (a *LogstashAdapter) Stream(logstream chan *router.Message) {
 
 		// Try to parse JSON-encoded m.Data. If it wasn't JSON, create an empty object
 		// and use the original data as the message.
-		if err = json.Unmarshal([]byte(m.Data), &data); err != nil {
+		if err = json.Unmarshal([]byte(m.Data), &data); err != nil || data == nil {
 			data = make(map[string]interface{})
 			data["message"] = m.Data
 		}

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -96,7 +96,7 @@ func TestStreamNullData(t *testing.T) {
 	err := json.Unmarshal([]byte(res), &data)
 	assert.Nil(err)
 
-	assert.Equal("foo bananas", data["message"])
+	assert.Equal("null", data["message"])
 	assert.Equal([]interface{}{"example", "tags"}, data["tags"])
 
 	var dockerInfo map[string]interface{}


### PR DESCRIPTION
@maxekman Fixes https://github.com/looplab/logspout-logstash/issues/49

The issue was that basically `null` is valid json and gets interpreted as `nil` by `json.Unmarshal` and then a crash occurs. (See #49 for a more detailed explanation of the problem)

This fix just makes sure that if the data is `nil` we change it to `data = make(map[string]interface{})` just like if the data is not valid json.

I have also included a regression test that I *think* will work. (Unfortunately I can do a `go get` `go install` and `go build` without error... but no files are created? And when I do a `go test logstash_test.go` I get `./logstash_test.go:58: undefined: LogstashAdapter`... do you know what I'm doing wrong? Sorry I have never really worked with go before)